### PR TITLE
Include --core-start parameter in CWL

### DIFF
--- a/predict_service/cwljob.py
+++ b/predict_service/cwljob.py
@@ -83,6 +83,9 @@ class PredictionsCwlJobGenerator(CwlJobGeneratorBase):
             job['models'] = [make_file_dict(os.path.join(self.model_files_directory, model)) for model in
                              model_filenames]
             job['sequence'] = make_file_dict(self.sequence_file)
+            del job['protein']
+            del job['model_filenames']
+            del job['assembly']
             if self.output_filename:
               job['output_filename'] = self.output_filename
             self._job = job

--- a/predict_service/example-predict-workflow.sh
+++ b/predict_service/example-predict-workflow.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+source ../env/bin/activate
+mkdir -p temp/t
+cwltool --tmpdir-prefix=$(pwd)/temp/t --tmp-outdir-prefix=$(pwd)/temp/t predict-workflow.cwl predict-workflow-job.json
+rm -r temp

--- a/predict_service/predict-tf-binding.cwl
+++ b/predict_service/predict-tf-binding.cwl
@@ -46,6 +46,10 @@ inputs:
     default: false
     inputBinding:
       prefix: -t
+  core_start:
+    type: int?
+    inputBinding:
+      prefix: --core-start
   output_filename:
     type: string
     default: "predictions.bed"

--- a/predict_service/predict-workflow-job.json
+++ b/predict_service/predict-workflow-job.json
@@ -1,0 +1,31 @@
+{
+  "sequence": {
+    "class": "File",
+    "path": "/Users/dcl9/Data/scratch/hg38-top793.fa"
+  },
+  "models": [
+    {
+      "class": "File",
+      "path": "/Users/dcl9/Data/tf-dna-predictions/models/E2F1_250nM_Bound_filtered_normalized_logistic_transformed_20bp_GCGC_1a2a3mer_format.model"
+    },
+    {
+      "class": "File",
+      "path": "/Users/dcl9/Data/tf-dna-predictions/models/E2F1_250nM_Bound_filtered_normalized_logistic_transformed_20bp_GCGG_1a2a3mer_format.model"
+    }
+  ],
+  "cores": [
+    "GCGC",
+    "GCGG"
+  ],
+  "width": 20,
+  "kmers": [
+    1,
+    2,
+    3
+  ],
+  "slope_intercept": false,
+  "transform": true,
+  "filter_threshold": 0.1933,
+  "core_start": null,
+  "output_filename": "E2f1_workflow.bed"
+}

--- a/predict_service/predict-workflow.cwl
+++ b/predict_service/predict-workflow.cwl
@@ -11,6 +11,7 @@ inputs:
   slope_intercept: boolean
   transform: boolean
   filter_threshold: float
+  core_start: int?
   output_filename: string
 outputs:
   predictions:
@@ -29,6 +30,7 @@ steps:
       kmers: kmers
       slope_intercept: slope_intercept
       transform: transform
+      core_start: core_start
     out: [predictions]
   combine:
     run: combine.cwl

--- a/predict_service/preference-workflow-job.json
+++ b/predict_service/preference-workflow-job.json
@@ -40,5 +40,6 @@
   "tf2":"E2f4",
   "tf1_threshold": 0.1933,
   "tf2_threshold": 0.162,
+  "core_start": null,
   "output_filename": "E2f1_vs_E2f4_workflow.bed"
 }

--- a/predict_service/preference-workflow.cwl
+++ b/predict_service/preference-workflow.cwl
@@ -12,6 +12,7 @@ inputs:
   kmers: int[]
   slope_intercept: boolean
   transform: boolean
+  core_start: int?
   # Preferences
   tf1: string
   tf2: string
@@ -35,6 +36,7 @@ steps:
       kmers: kmers
       slope_intercept: slope_intercept
       transform: transform
+      core_start: core_start
     out: [predictions]
   predict2:
     run: predict-tf-binding.cwl
@@ -48,6 +50,7 @@ steps:
       kmers: kmers
       slope_intercept: slope_intercept
       transform: transform
+      core_start: core_start
     out: [predictions]
   combine1:
     run: combine.cwl


### PR DESCRIPTION
core_start has been added as an optional int parameter to the CWL workflow and the predict tool. When not null in the input job, it will be passed to the command-line for predict. Otherwise it is skipped.

Tested by running workflows directly with included example scripts.

Fixes #4 