### PR TITLE
Refactors worker client to improve error handling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,7 @@
+language: python
+python:
+  - "2.7"
+install:
+  - "pip install --upgrade setuptools"
+  - "pip install -r requirements.txt"
+script: nosetests

--- a/client.py
+++ b/client.py
@@ -153,7 +153,7 @@ class PredictionsClient(object):
                 except Exception:
                     # There was some exception, log it and send it back
                     s = traceback.format_exc()
-                    print('Exception making predictions', s)
+                    print('Exception making predictions:\n', s)
                     self.mark_job_error(job, str(s))
                     to_remove.append(index)
             # Now remove the completed or errored jobs

--- a/predict_service/cwljob.py
+++ b/predict_service/cwljob.py
@@ -83,9 +83,8 @@ class PredictionsCwlJobGenerator(CwlJobGeneratorBase):
             job['models'] = [make_file_dict(os.path.join(self.model_files_directory, model)) for model in
                              model_filenames]
             job['sequence'] = make_file_dict(self.sequence_file)
-            del job['protein']
-            del job['model_filenames']
-            del job['assembly']
+            # Delete keys that are not used later. Use pop to ignore if not present
+            [job.pop(k,None) for k in ('protein','model_filenames','assembly')]
             if self.output_filename:
               job['output_filename'] = self.output_filename
             self._job = job
@@ -121,9 +120,8 @@ class PreferencesCwlJobGenerator(CwlJobGeneratorBase):
             job['tf1'], job['tf2'] = job['proteins']
             job['tf1_threshold'], job['tf2_threshold'] = job['filter_thresholds']
             job['sequence'] = make_file_dict(self.sequence_file)
-            del job['proteins']
-            del job['model_filenames']
-            del job['assembly']
+            # Delete keys that are not used later. Use pop to ignore if not present
+            [job.pop(k,None) for k in ('proteins','model_filenames','assembly')]
             if self.output_filename:
               job['output_filename'] = self.output_filename
             self._job = job

--- a/predict_service/tests/test_cwljob.py
+++ b/predict_service/tests/test_cwljob.py
@@ -2,35 +2,35 @@ import tempfile
 from unittest import TestCase
 
 import test_data
-from predict_service.cwljob import CwlJobGenerator
+from predict_service.cwljob import PredictionsCwlJobGenerator
 
 
 class CwlJobGeneratorTestCase(TestCase):
     def test_model_dict(self):
-        g = CwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models')
+        g = PredictionsCwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models')
         self.assertIsNotNone(g.job)
         self.assertNotIn('models', test_data.CONFIG_2X2, 'test dataset should have model_filenames')
         self.assertIn('models', g.job, 'generated job dict should just have models')
         self.assertEqual(g.job['sequence'], {'class': 'File', 'path': 'seq.fa'}, 'job should have sequence file object')
 
     def test_writes_json(self):
-        g = CwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models')
+        g = PredictionsCwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models')
         output_file = tempfile.NamedTemporaryFile()
         self.assertEqual(output_file.tell(), 0)
         g.write_json(output_file)
         self.assertNotEqual(output_file.tell(), 0, 'write_json should have written to the file')
 
     def test_includes_output_filename(self):
-        g = CwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models', 'myfile.out')
+        g = PredictionsCwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models', 'myfile.out')
         self.assertIn('output_filename', g.job)
         self.assertEqual(g.job['output_filename'], 'myfile.out')
 
     def test_omits_output_filename(self):
-        g = CwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models')
+        g = PredictionsCwlJobGenerator(test_data.CONFIG_2X2, 'seq.fa', '/models')
         self.assertNotIn('output_filename', g.job)
 
     def test_matrixes_models(self):
-        g = CwlJobGenerator(test_data.CONFIG_1X3, 'seq.fa', '/models')
+        g = PredictionsCwlJobGenerator(test_data.CONFIG_1X3, 'seq.fa', '/models')
         self.assertEqual(len(test_data.CONFIG_1X3['model_filenames']), 1)
         self.assertEqual(len(test_data.CONFIG_1X3['cores']), 3)
         self.assertEqual(len(g.job['models']), 3)
@@ -38,8 +38,8 @@ class CwlJobGeneratorTestCase(TestCase):
 
     def test_fails_without_params(self):
         with self.assertRaises(ValueError):
-            CwlJobGenerator(None, 'seq.fa', '/models')
+            PredictionsCwlJobGenerator(None, 'seq.fa', '/models')
         with self.assertRaises(ValueError):
-            CwlJobGenerator({}, None, '/models')
+            PredictionsCwlJobGenerator({}, None, '/models')
         with self.assertRaises(ValueError):
-            CwlJobGenerator({}, 'seq.fa', None)
+            PredictionsCwlJobGenerator({}, 'seq.fa', None)

--- a/predict_service/tests/test_runner.py
+++ b/predict_service/tests/test_runner.py
@@ -9,7 +9,6 @@ class PredictionRunnerTestCase(TestCase):
     sequence = 'predict_service/tests/test_sequence.fa'
     model = 'ABCD_1234(AB)'
     config = 'predict_service/tests/test_config.yaml'
-    workflow = 'predict_service/tests/test_workflow.cwl'
     models_dir = '/models'
 
     def setUp(self):
@@ -19,36 +18,36 @@ class PredictionRunnerTestCase(TestCase):
         shutil.rmtree(self.output_dir)
 
     def test_writes_json_order(self):
-        p = PredictionRunner(self.workflow, self.sequence, self.model, self.config, self.models_dir, self.output_dir)
+        p = PredictionRunner(self.sequence, self.model, self.config, self.models_dir, self.output_dir)
         p.write_json_order()
 
     def test_fails_with_missing_sequence(self):
         with self.assertRaises(ValueError):
-            PredictionRunner(self.workflow, None, self.model, self.config, self.models_dir, self.output_dir)
+            PredictionRunner(None, self.model, self.config, self.models_dir, self.output_dir)
 
     def test_fails_with_missing_model(self):
         with self.assertRaises(ValueError):
-            PredictionRunner(self.workflow, self.sequence, None, self.config, self.models_dir, self.output_dir)
+            PredictionRunner(self.sequence, None, self.config, self.models_dir, self.output_dir)
 
     def test_fails_with_missing_config(self):
         with self.assertRaises(ValueError):
-            PredictionRunner(self.workflow, self.sequence, self.model, None, self.models_dir, self.output_dir)
+            PredictionRunner(self.sequence, self.model, None, self.models_dir, self.output_dir)
 
     def test_generates_order_file_name(self):
-        p = PredictionRunner(self.workflow, self.sequence, self.model, self.config, self.models_dir, self.output_dir)
+        p = PredictionRunner(self.sequence, self.model, self.config, self.models_dir, self.output_dir)
         order_file_name = p.order_file_name
         self.assertIn('.json', order_file_name)
         self.assertIn(self.model, order_file_name)
 
     def test_generates_ooutput_file_name(self):
-        p = PredictionRunner(self.workflow, self.sequence, self.model, self.config, self.models_dir, self.output_dir)
+        p = PredictionRunner(self.sequence, self.model, self.config, self.models_dir, self.output_dir)
         output_file_name = p.output_file_name
         self.assertIn('.bed', output_file_name)
         self.assertIn(self.model, output_file_name)
 
     @patch('predict_service.runner.cwl_main')
     def test_runs_cwltool_gets_output(self, mock_cwl_main):
-        p = PredictionRunner(self.workflow, self.sequence, self.model, self.config, self.models_dir, self.output_dir)
+        p = PredictionRunner(self.sequence, self.model, self.config, self.models_dir, self.output_dir)
         def side_effect(args, stdout, stderr):
           print >>stdout, '{"predictions":{"path": "/preds.bed","class": "File","size": 124}}'
           return 0
@@ -59,7 +58,7 @@ class PredictionRunnerTestCase(TestCase):
 
     @patch('predict_service.runner.cwl_main')
     def test_handles_cwltool_failures(self, mock_cwl_main):
-        p = PredictionRunner(self.workflow, self.sequence, self.model, self.config, self.models_dir, self.output_dir)
+        p = PredictionRunner(self.sequence, self.model, self.config, self.models_dir, self.output_dir)
         def side_effect(args, stdout, stderr):
           print >>stderr, 'error in cwl_main'
           return 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ isodate==0.5.4
 keepalive==0.5
 mistune==0.7.3
 mock==2.0.0
+nose==1.3.7
 pbr==1.10.0
 pyparsing==2.1.8
 PyYAML==3.11

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,12 @@
 avro==1.8.1
 cwltool==1.0.20160811184335
+funcsigs==1.0.2
 html5lib==0.999999999
 isodate==0.5.4
 keepalive==0.5
 mistune==0.7.3
+mock==2.0.0
+pbr==1.10.0
 pyparsing==2.1.8
 PyYAML==3.11
 rdflib==4.2.1


### PR DESCRIPTION
- Rather than running the entire claim process in async, the loop happens on the main thread, claims a job, and runs the predictions worker on another thread
- Results of the async call are tracked in a list and checked on each pass of the loop
- Full stacktraces should be reported back to the API (and are printed to stdout)

Fixes #1 