### PR TITLE
Improves performance by running in one container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,7 @@ ENV PATH /opt/predict-tf-binding/:$PATH
 ### Step 4: Install Predict-TF-Preference from GitHub
 WORKDIR /opt/
 RUN git clone https://github.com/Duke-GCB/Predict-TF-Preference.git predict-tf-preference
-ENV PATH /opt/predict-tf-binding/:$PATH
+ENV PATH /opt/predict-tf-preference/:$PATH
 
 # Switch to non-root user
 RUN useradd -m worker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,47 @@
-FROM python:2.7.11
-MAINTAINER dan.leehr@duke.edu
+FROM ubuntu:xenial
+MAINTAINER "Dan Leehr" dan.leehr@duke.edu
 
-# Install docker client so that cwltool can call it
-RUN curl -sSL https://get.docker.com/ | sh
+RUN apt-get update && apt-get install -y \
+  git \
+  python python-pip \
+  r-base
 
+### Step 1: Install the worker and its dependencies
 ADD requirements.txt /opt/tf-predictions-worker/
 WORKDIR /opt/tf-predictions-worker
 RUN pip install -r requirements.txt
 
 ADD . /opt/tf-predictions-worker/
 ENV PATH /opt/tf-predictions-worker/:$PATH
+
+### Step 2: Install LIBSVM, needed by predict-tf-binding
+# Makefile has no install target, so we compile and update PATH
+# Owned by root and placed in /opt
+
+ENV LIBSVM_VER 321
+RUN curl -SL https://github.com/cjlin1/libsvm/archive/v${LIBSVM_VER}.tar.gz | tar -xzC /opt # makes /opt/libsvm-321
+WORKDIR /opt/libsvm-${LIBSVM_VER}
+RUN make
+
+# Build shared lib for python bindings
+WORKDIR /opt/libsvm-${LIBSVM_VER}/python
+RUN make
+
+ENV PATH $PATH:/opt/libsvm-${LIBSVM_VER}
+
+### Step 2: Install Predict-TF-Binding from GitHub
+WORKDIR /opt/
+RUN git clone https://github.com/Duke-GCB/Predict-TF-Binding.git predict-tf-binding
+RUN pip install -r /opt/predict-tf-binding/requirements.txt
+ENV PATH /opt/predict-tf-binding/:$PATH
+
+### Step 3: Install Predict-TF-Preference from GitHub
+WORKDIR /opt/
+RUN git clone https://github.com/Duke-GCB/Predict-TF-Preference.git predict-tf-preference
+ENV PATH /opt/predict-tf-binding/:$PATH
+
+# Switch to non-root user
+RUN useradd -m worker
+USER worker
 
 CMD client.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -27,15 +27,19 @@ RUN make
 WORKDIR /opt/libsvm-${LIBSVM_VER}/python
 RUN make
 
-ENV PATH $PATH:/opt/libsvm-${LIBSVM_VER}
+# Install libsvm and python bindings
+# These have no installer so we place the library and python bindings manually
+RUN cp /opt/libsvm-${LIBSVM_VER}/libsvm.so* /usr/lib/
+RUN ldconfig
+RUN cp /opt/libsvm-${LIBSVM_VER}/python/*.py /usr/local/lib/python2.7/dist-packages/
 
-### Step 2: Install Predict-TF-Binding from GitHub
+### Step 3: Install Predict-TF-Binding from GitHub
 WORKDIR /opt/
 RUN git clone https://github.com/Duke-GCB/Predict-TF-Binding.git predict-tf-binding
 RUN pip install -r /opt/predict-tf-binding/requirements.txt
 ENV PATH /opt/predict-tf-binding/:$PATH
 
-### Step 3: Install Predict-TF-Preference from GitHub
+### Step 4: Install Predict-TF-Preference from GitHub
 WORKDIR /opt/
 RUN git clone https://github.com/Duke-GCB/Predict-TF-Preference.git predict-tf-preference
 ENV PATH /opt/predict-tf-binding/:$PATH

--- a/config.py
+++ b/config.py
@@ -7,7 +7,6 @@ PREDICTIONS_CONFIG_FILE = "PREDICTIONS_CONFIG_FILE"
 PREFERENCES_CONFIG_FILE = "PREFERENCES_CONFIG_FILE"
 WORKER_USERNAME = "WORKER_USERNAME"
 WORKER_PASSWORD = "WORKER_PASSWORD"
-TMP_PREFIX = "TMP_PREFIX"
 
 class Config(object):
 
@@ -22,7 +21,6 @@ class Config(object):
       preferences_config_file: Path to the tracks-preferences.yaml config file providing metadata for model files
       worker_username: str: username required for worker specific prediction API endpoints
       worker_password: str: password required for worker specific prediction API endpoints
-      tmp_prefix: str: prefix to use for CWL tmpdir-prefix and tmp-outdir-prefix
       """
 
       self.base_url = os.environ.get(BASE_URL)
@@ -32,4 +30,3 @@ class Config(object):
       self.preferences_config_file = os.environ.get(PREFERENCES_CONFIG_FILE)
       self.worker_username = os.environ.get(WORKER_USERNAME)
       self.worker_password = os.environ.get(WORKER_PASSWORD)
-      self.tmp_prefix = os.environ.get(TMP_PREFIX)

--- a/predict_service/change-precision.cwl
+++ b/predict_service/change-precision.cwl
@@ -1,6 +1,6 @@
 cwlVersion: v1.0
 baseCommand: ['change_precision.py','--spaces']
-requirements:
+hints:
   DockerRequirement:
     dockerPull: dukegcb/predict-tf-binding
 class: CommandLineTool

--- a/predict_service/combine.cwl
+++ b/predict_service/combine.cwl
@@ -1,7 +1,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: ['combine_predictions_sql.py']
-requirements:
+hints:
   DockerRequirement:
     dockerPull: dukegcb/predict-tf-binding
 inputs:

--- a/predict_service/filter-tf-preference-threshold.cwl
+++ b/predict_service/filter-tf-preference-threshold.cwl
@@ -1,6 +1,6 @@
 cwlVersion: v1.0
 class: CommandLineTool
-requirements:
+hints:
   DockerRequirement:
     dockerPull: dukegcb/predict-tf-preference
 inputs:

--- a/predict_service/filter.cwl
+++ b/predict_service/filter.cwl
@@ -1,6 +1,6 @@
 cwlVersion: v1.0
 baseCommand: ['filter.py','--spaces']
-requirements:
+hints:
   DockerRequirement:
     dockerPull: dukegcb/predict-tf-binding
 class: CommandLineTool

--- a/predict_service/predict-tf-binding.cwl
+++ b/predict_service/predict-tf-binding.cwl
@@ -1,7 +1,7 @@
 cwlVersion: v1.0
 class: CommandLineTool
 baseCommand: predict_tf_binding.py
-requirements:
+hints:
   DockerRequirement:
     dockerPull: dukegcb/predict-tf-binding
 inputs:

--- a/predict_service/predict-tf-preference.cwl
+++ b/predict_service/predict-tf-preference.cwl
@@ -1,6 +1,6 @@
 cwlVersion: v1.0
 class: CommandLineTool
-requirements:
+hints:
   DockerRequirement:
     dockerPull: dukegcb/predict-tf-preference
 inputs:

--- a/predict_service/runner.py
+++ b/predict_service/runner.py
@@ -49,7 +49,7 @@ class PredictionRunner:
     Class to encapsulate running of prediction on custom sequences using a CWL workflow and internal model/metadata
     """
     def __init__(self, sequence_file, model_identifier, config_file_path, model_files_directory,
-                 output_directory, strategy=strategy_predict, tmp_prefix=None):
+                 output_directory, strategy=strategy_predict):
         """
         Creates a PredictionRunner ready to run
         Parameters
@@ -61,7 +61,6 @@ class PredictionRunner:
         model_files_directory: Directory containing model files referenced in above config file
         output_directory: Where to store output data and intermediate JSON jobs
         strategy: Tuple of (CWL workflow, CwlJobGenerator, and mode)
-        tmp_prefix: Prefix to use with CWL tmpdir and tmp-outdir
 
         """
         self.timestamp = timestamp()
@@ -73,7 +72,6 @@ class PredictionRunner:
         self.config_file_path = config_file_path
         self.model_files_directory = model_files_directory
         self.output_directory = output_directory
-        self.tmp_prefix = tmp_prefix
         # Force config and job loading to validate inputs
         self._load()
 
@@ -182,10 +180,7 @@ class PredictionRunner:
         # command-line arguments in a list for argparse to parse,
         # this is still simpler than the internal building blocks
         out, err = StringIO.StringIO(), StringIO.StringIO()
-        argsl = ['--outdir', self.output_directory]
-        if self.tmp_prefix:
-            argsl.extend(['--tmpdir-prefix', self.tmp_prefix])
-            argsl.extend(['--tmp-outdir-prefix', self.tmp_prefix])
+        argsl = ['--no-container', '--outdir', self.output_directory]
         argsl.extend([self.workflow, self.order_file_path])
         rc = cwl_main(argsl, stdout=out, stderr=err)
         out_value, err_value = out.getvalue(), err.getvalue()

--- a/worker.py
+++ b/worker.py
@@ -25,6 +25,5 @@ class PredictionsWorker(object):
                                   config_file,
                                   self.config.model_files_dir,
                                   self.config.output_dir,
-                                  strategy,
-                                  self.config.tmp_prefix)
+                                  strategy)
         return self.extract_predictions(runner.run())


### PR DESCRIPTION
Speeds up predictions by installing predict-tf-binding, predict-tf-preference, and all their dependencies in the worker. Also updates the worker cwl execution to specify `--no-container`.

This will also allow us to simplify the ansible playbooks since the worker container won't be talking to the docker socket, launching new containers, or need to have identical directory paths as its host.

Fixes #10 

