### PR TITLE
Updates CWL for predict-tf-binding to use multiprocessing

### DIFF
--- a/predict_service/predict-tf-binding.cwl
+++ b/predict_service/predict-tf-binding.cwl
@@ -16,11 +16,11 @@ inputs:
       itemSeparator: " "
       separate: true
   model:
-    type: File
+    type: File[]
     inputBinding:
       prefix: -m
   core:
-    type: string
+    type: string[]
     inputBinding:
       prefix: -c
   width:
@@ -50,13 +50,8 @@ inputs:
     type: int?
     inputBinding:
       prefix: --core-start
-  output_filename:
-    type: string
-    default: "predictions.bed"
-    inputBinding:
-      prefix: -o
 outputs:
   predictions:
-    type: File
+    type: File[]
     outputBinding:
-      glob: $(inputs.output_filename)
+      glob: "predict_output_*.bed"

--- a/predict_service/predict-workflow.cwl
+++ b/predict_service/predict-workflow.cwl
@@ -1,7 +1,5 @@
 cwlVersion: v1.0
 class: Workflow
-requirements:
-  - class: ScatterFeatureRequirement
 inputs:
   sequence: File
   models: File[]
@@ -20,8 +18,6 @@ outputs:
 steps:
   predict:
     run: predict-tf-binding.cwl
-    scatter: [model, core]
-    scatterMethod: dotproduct
     in:
       sequence: sequence
       model: models

--- a/predict_service/preference-workflow.cwl
+++ b/predict_service/preference-workflow.cwl
@@ -1,7 +1,5 @@
 cwlVersion: v1.0
 class: Workflow
-requirements:
-  - class: ScatterFeatureRequirement
 inputs:
   # Predictions
   sequence: File
@@ -26,8 +24,6 @@ outputs:
 steps:
   predict1:
     run: predict-tf-binding.cwl
-    scatter: [model, core]
-    scatterMethod: dotproduct
     in:
       sequence: sequence
       model: models1
@@ -40,8 +36,6 @@ steps:
     out: [predictions]
   predict2:
     run: predict-tf-binding.cwl
-    scatter: [model, core]
-    scatterMethod: dotproduct
     in:
       sequence: sequence
       model: models2


### PR DESCRIPTION
- Now passes arrays of cores and models to predict tool, allowing it to predict on multiple cores simultaneously