### PR TITLE
Upgrade predictors to python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,8 @@
-FROM ubuntu:xenial
+FROM python:3.7
 LABEL maintainer="dan.leehr@duke.edu"
 
 RUN apt-get update && apt-get install -y \
   git \
-  python3 python3-pip\
   r-base
 
 ### Step 1: Install the worker and its dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,13 +15,13 @@ ENV PATH /opt/tf-predictions-worker/:$PATH
 
 ### Step 3: Install Predict-TF-Binding from GitHub
 WORKDIR /opt/
-RUN git clone -b python3 https://github.com/Duke-GCB/Predict-TF-Binding.git predict-tf-binding
+RUN git clone https://github.com/Duke-GCB/Predict-TF-Binding.git predict-tf-binding
 RUN pip3 install -r /opt/predict-tf-binding/requirements.txt
 ENV PATH /opt/predict-tf-binding/:$PATH
 
 ### Step 4: Install Predict-TF-Preference from GitHub
 WORKDIR /opt/
-RUN git clone -b python3 https://github.com/Duke-GCB/Predict-TF-Preference.git predict-tf-preference
+RUN git clone https://github.com/Duke-GCB/Predict-TF-Preference.git predict-tf-preference
 ENV PATH /opt/predict-tf-preference/:$PATH
 
 # Switch to non-root user

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM ubuntu:xenial
-MAINTAINER "Dan Leehr" dan.leehr@duke.edu
+LABEL maintainer="dan.leehr@duke.edu"
 
 RUN apt-get update && apt-get install -y \
   git \
-  python3 python3-pip python-pip\
+  python3 python3-pip\
   r-base
 
 ### Step 1: Install the worker and its dependencies
@@ -14,34 +14,15 @@ RUN pip3 install -r requirements.txt
 ADD . /opt/tf-predictions-worker/
 ENV PATH /opt/tf-predictions-worker/:$PATH
 
-### Step 2: Install LIBSVM, needed by predict-tf-binding
-# Makefile has no install target, so we compile and update PATH
-# Owned by root and placed in /opt
-
-ENV LIBSVM_VER 321
-RUN curl -SL https://github.com/cjlin1/libsvm/archive/v${LIBSVM_VER}.tar.gz | tar -xzC /opt # makes /opt/libsvm-321
-WORKDIR /opt/libsvm-${LIBSVM_VER}
-RUN make
-
-# Build shared lib for python bindings
-WORKDIR /opt/libsvm-${LIBSVM_VER}/python
-RUN make
-
-# Install libsvm and python bindings
-# These have no installer so we place the library and python bindings manually
-RUN cp /opt/libsvm-${LIBSVM_VER}/libsvm.so* /usr/lib/
-RUN ldconfig
-RUN cp /opt/libsvm-${LIBSVM_VER}/python/*.py /usr/local/lib/python2.7/dist-packages/
-
 ### Step 3: Install Predict-TF-Binding from GitHub
 WORKDIR /opt/
-RUN git clone https://github.com/Duke-GCB/Predict-TF-Binding.git predict-tf-binding
-RUN pip install -r /opt/predict-tf-binding/requirements.txt
+RUN git clone -b python3 https://github.com/Duke-GCB/Predict-TF-Binding.git predict-tf-binding
+RUN pip3 install -r /opt/predict-tf-binding/requirements.txt
 ENV PATH /opt/predict-tf-binding/:$PATH
 
 ### Step 4: Install Predict-TF-Preference from GitHub
 WORKDIR /opt/
-RUN git clone https://github.com/Duke-GCB/Predict-TF-Preference.git predict-tf-preference
+RUN git clone -b python3 https://github.com/Duke-GCB/Predict-TF-Preference.git predict-tf-preference
 ENV PATH /opt/predict-tf-preference/:$PATH
 
 # Switch to non-root user


### PR DESCRIPTION
Updates Dockerfile to install/run predict-tf-binding and predict-tf-preference using python 3 (See https://github.com/Duke-GCB/Predict-TF-Binding/pull/46 and https://github.com/Duke-GCB/Predict-TF-Preference/pull/5)

- Switches base image to python 3.7, since installing python 3 on top of ubuntu could not install predict-tf-binding dependencies correctly.
- Removes unnecessary LIBSVM installation (see https://github.com/Duke-GCB/Predict-TF-Binding/pull/46)

Tested on imads-dev
